### PR TITLE
separate each into its own file

### DIFF
--- a/1804-fxci.ipxe
+++ b/1804-fxci.ipxe
@@ -1,0 +1,16 @@
+#!ipxe
+
+echo ===> Entered ubuntu1804-preseed
+set kernel_url http://data.srv.releng.mdc1.mozilla.com/repos/kickstart/
+set preseed_url http://data.srv.releng.mdc1.mozilla.com/repos/kickstart/ubuntu_18.04_x64_moonshot.preseed
+echo Kernel: ${kernel_url}u18.linux
+echo Initrd: ${kernel_url}u18.initrd.gz
+echo Preseed: ${preseed_url}
+sleep 2
+
+imgfetch ${kernel_url}u18.linux || goto load_fail
+imgfetch ${kernel_url}u18.initrd.gz || goto load_fail
+
+kernel ${kernel_url}u18.linux auto=true priority=critical vga=788 initrd=u18.initrd.gz auto=true url=${preseed_url} priority=critical interface=auto ---
+initrd ${kernel_url}u18.initrd.gz
+boot || goto load_fail

--- a/1804-ubuntu-hosted.ipxe
+++ b/1804-ubuntu-hosted.ipxe
@@ -1,0 +1,15 @@
+#!ipxe
+
+echo ===> Entered ubuntu1804-ubuntu
+set kernel_url http://archive.ubuntu.com/ubuntu/dists/bionic/main/installer-amd64/current/images/netboot/ubuntu-installer/amd64/
+echo Kernel: ${kernel_url}linux
+echo Initrd: ${kernel_url}initrd.gz
+sleep 2
+
+imgfetch ${kernel_url}linux || goto load_fail
+imgfetch ${kernel_url}initrd.gz || goto load_fail
+
+echo Files fetched successfully. Booting...
+kernel ${kernel_url}linux auto=true priority=critical vga=788 initrd=initrd.gz ---
+initrd ${kernel_url}initrd.gz
+boot || goto load_fail

--- a/1804-ubuntu-mdc1.ipxe
+++ b/1804-ubuntu-mdc1.ipxe
@@ -1,0 +1,14 @@
+#!ipxe
+
+echo ===> Entered ubuntu1804-data.mdc1
+set kernel_url http://data.srv.releng.mdc1.mozilla.com/repos/kickstart/
+echo Kernel: ${kernel_url}u18.linux
+echo Initrd: ${kernel_url}u18.initrd.gz
+sleep 2
+
+imgfetch ${kernel_url}u18.linux || goto load_fail
+imgfetch ${kernel_url}u18.initrd.gz || goto load_fail
+
+kernel ${kernel_url}u18.linux auto=true priority=critical vga=788 initrd=u18.initrd.gz ---
+initrd ${kernel_url}u18.initrd.gz
+boot || goto load_fail

--- a/custom.ipxe
+++ b/custom.ipxe
@@ -5,60 +5,27 @@ console --picture http://boot.ipxe.org/ipxe.png
 clear custom_choice
 menu RELOPS Linux HW PXE Menu - 07/2025
 item --gap Ubuntu 18.04 Server
-item ubuntu1804-preseed ${space} Image with Preseed (WORKING)
+item ubuntu1804-auto ${space} Run Automated 18.04 Installer for FXCI (WORKING)
 item ubuntu1804-ubuntu ${space} Run Installer - archive.ubuntu.com (WORKING)
 item ubuntu1804-data.mdc1 ${space} Run Installer - MDC1 (WORKING)
 item --gap Ubuntu 24.04 Server
-item ubuntu2404-installer ${space} Run Installer
+item ubuntu2404-auto ${space} Run Automated Install 24.04
+item ubuntu2404-hosted ${space} Run 24.04 Installer for FXCI (Hosted)
 choose custom_choice || goto custom
 echo ${cls}
 goto ${custom_choice}
 
-
 :ubuntu1804-ubuntu
-echo ===> Entered ubuntu1804-ubuntu
-set kernel_url http://archive.ubuntu.com/ubuntu/dists/bionic/main/installer-amd64/current/images/netboot/ubuntu-installer/amd64/
-echo Kernel: ${kernel_url}linux
-echo Initrd: ${kernel_url}initrd.gz
-sleep 2
-
-imgfetch ${kernel_url}linux || goto load_fail
-imgfetch ${kernel_url}initrd.gz || goto load_fail
-
-echo Files fetched successfully. Booting...
-kernel ${kernel_url}linux auto=true priority=critical vga=788 initrd=initrd.gz ---
-initrd ${kernel_url}initrd.gz
-boot || goto load_fail
+chain https://raw.githubusercontent.com/mozilla-platform-ops/netboot.xyz-custom/refs/heads/master/1804-ubuntu-hosted.ipxe
 
 :ubuntu1804-data.mdc1
-echo ===> Entered ubuntu1804-data.mdc1
-set kernel_url http://data.srv.releng.mdc1.mozilla.com/repos/kickstart/
-echo Kernel: ${kernel_url}u18.linux
-echo Initrd: ${kernel_url}u18.initrd.gz
-sleep 2
+chain https://raw.githubusercontent.com/mozilla-platform-ops/netboot.xyz-custom/refs/heads/master/1804-ubuntu-mdc1.ipxe
 
-imgfetch ${kernel_url}u18.linux || goto load_fail
-imgfetch ${kernel_url}u18.initrd.gz || goto load_fail
+:ubuntu1804-auto
+chain https://raw.githubusercontent.com/mozilla-platform-ops/netboot.xyz-custom/refs/heads/master/1804-fxci.ipxe
 
-kernel ${kernel_url}u18.linux auto=true priority=critical vga=788 initrd=u18.initrd.gz ---
-initrd ${kernel_url}u18.initrd.gz
-boot || goto load_fail
-
-:ubuntu1804-preseed
-echo ===> Entered ubuntu1804-preseed
-set kernel_url http://data.srv.releng.mdc1.mozilla.com/repos/kickstart/
-set preseed_url http://data.srv.releng.mdc1.mozilla.com/repos/kickstart/ubuntu_18.04_x64_moonshot.preseed
-echo Kernel: ${kernel_url}u18.linux
-echo Initrd: ${kernel_url}u18.initrd.gz
-echo Preseed: ${preseed_url}
-sleep 2
-
-imgfetch ${kernel_url}u18.linux || goto load_fail
-imgfetch ${kernel_url}u18.initrd.gz || goto load_fail
-
-kernel ${kernel_url}u18.linux auto=true priority=critical vga=788 initrd=u18.initrd.gz auto=true url=${preseed_url} priority=critical interface=auto ---
-initrd ${kernel_url}u18.initrd.gz
-boot || goto load_fail
-
-:ubuntu2404-installer
+:ubuntu2404-auto
 chain https://raw.githubusercontent.com/mozilla-platform-ops/netboot.xyz-custom/refs/heads/master/2404-server-auto.ipxe
+
+:ubuntu2404-hosted
+chain https://raw.githubusercontent.com/mozilla-platform-ops/netboot.xyz-custom/refs/heads/master/2404-server.ipxe


### PR DESCRIPTION
We want 24.04 and 18.04 installers, one to automate installation of fxci hosts and one to provide a full installer for manual reimaging.